### PR TITLE
Extract raster images from pdf

### DIFF
--- a/packages/markitdown-pymupdf-plugin/pyproject.toml
+++ b/packages/markitdown-pymupdf-plugin/pyproject.toml
@@ -40,6 +40,11 @@ path = "src/markitdown_pymupdf_plugin/__about__.py"
 [project.entry-points."markitdown.plugin"]
 pymupdf_plugin = "markitdown_pymupdf_plugin"
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+]
+
 [tool.hatch.envs.types]
 extra-dependencies = [
   "mypy>=1.0.0",

--- a/packages/markitdown-pymupdf-plugin/tests/test_image_extraction.py
+++ b/packages/markitdown-pymupdf-plugin/tests/test_image_extraction.py
@@ -1,0 +1,86 @@
+import io
+import os
+import shutil
+import warnings
+from pathlib import Path
+import pytest
+
+import pymupdf as pymupdf
+from markitdown import DocumentConverterResult, StreamInfo
+from markitdown_pymupdf_plugin._plugin import PyMuPdfConverter
+
+# Suppress specific DeprecationWarning messages from SWIG-generated code in PyMuPDF
+warnings.filterwarnings("ignore", message="builtin type SwigPyPacked has no __module__ attribute", category=DeprecationWarning)
+warnings.filterwarnings("ignore", message="builtin type SwigPyObject has no __module__ attribute", category=DeprecationWarning)
+warnings.filterwarnings("ignore", message="builtin type swigvarlink has no __module__ attribute", category=DeprecationWarning)
+
+@pytest.fixture
+def setup_teardown_pdf_and_dirs():
+    converter = PyMuPdfConverter()
+    image_source_path = "packages/markitdown/tests/test_files/test.jpg"
+    text_content_default = "Hello, PyMuPDF with image!"
+    text_content_custom = "Hello, PyMuPDF with custom image!"
+    temp_pdf_path = "temp_test_file.pdf"
+    default_img_dir = os.path.join(os.path.dirname(temp_pdf_path), "img")
+    custom_img_dir = "custom_images_output"
+
+    # Create a dummy PDF with an image
+    doc = pymupdf.open()
+    page = doc.new_page()
+    page.insert_text((10, 10), text_content_default)
+    page.insert_image(page.rect, filename=image_source_path)
+    pdf_bytes = doc.tobytes()
+    doc.close()
+
+    with open(temp_pdf_path, "wb") as f:
+        f.write(pdf_bytes)
+
+    yield converter, pdf_bytes, temp_pdf_path, default_img_dir, custom_img_dir, text_content_default, text_content_custom, image_source_path
+
+    if os.path.exists(temp_pdf_path):
+        os.remove(temp_pdf_path)
+    if os.path.exists(default_img_dir):
+        shutil.rmtree(default_img_dir)
+    if os.path.exists(custom_img_dir):
+        shutil.rmtree(custom_img_dir)
+
+class TestPyMuPdfImageExtraction:
+
+    def test_convert_with_image_extraction_default_dir(self, setup_teardown_pdf_and_dirs):
+        converter, pdf_bytes, temp_pdf_path, default_img_dir, _, text_content_default, _, _ = setup_teardown_pdf_and_dirs
+        result = converter.convert(
+            io.BytesIO(pdf_bytes), 
+            StreamInfo(extension=".pdf", mimetype="application/pdf", local_path=temp_pdf_path)
+        )
+        assert isinstance(result, DocumentConverterResult)
+        assert text_content_default in result.markdown
+        assert result.extracted_image_paths is not None
+        assert len(result.extracted_image_paths) == 1
+        
+        expected_image_path = os.path.join(default_img_dir, "page_1_image_1.jpeg")
+        assert os.path.exists(expected_image_path)
+        assert result.extracted_image_paths[0] == expected_image_path
+
+    def test_convert_with_image_extraction_custom_dir(self, setup_teardown_pdf_and_dirs):
+        converter, _, _, _, custom_img_dir, _, text_content_custom, image_source_path = setup_teardown_pdf_and_dirs
+        # Re-create PDF with custom text for this test
+        doc = pymupdf.open()
+        page = doc.new_page()
+        page.insert_text((10, 10), text_content_custom)
+        page.insert_image(page.rect, filename=image_source_path)
+        custom_pdf_bytes = doc.tobytes()
+        doc.close()
+
+        result = converter.convert(
+            io.BytesIO(custom_pdf_bytes), 
+            StreamInfo(extension=".pdf", mimetype="application/pdf"),
+            images_output_dir=custom_img_dir
+        )
+        assert isinstance(result, DocumentConverterResult)
+        assert text_content_custom in result.markdown
+        assert result.extracted_image_paths is not None
+        assert len(result.extracted_image_paths) == 1
+        
+        expected_image_path = os.path.join(custom_img_dir, "page_1_image_1.jpeg")
+        assert os.path.exists(expected_image_path)
+        assert result.extracted_image_paths[0] == expected_image_path

--- a/packages/markitdown-pymupdf-plugin/tests/test_pymupdf_plugin.py
+++ b/packages/markitdown-pymupdf-plugin/tests/test_pymupdf_plugin.py
@@ -1,57 +1,65 @@
 import io
-import unittest
-from unittest.mock import MagicMock
+import os
+import shutil
+import warnings
+from unittest.mock import MagicMock, ANY
 
-import fitz
+import pymupdf as pymupdf
 from markitdown import MarkItDown, DocumentConverterResult, StreamInfo
 from markitdown_pymupdf_plugin._plugin import PyMuPdfConverter, register_converters
 
-class TestPyMuPdfPlugin(unittest.TestCase):
+# Suppress specific DeprecationWarning messages from SWIG-generated code in PyMuPDF
+warnings.filterwarnings("ignore", message="builtin type SwigPyPacked has no __module__ attribute", category=DeprecationWarning)
+warnings.filterwarnings("ignore", message="builtin type SwigPyObject has no __module__ attribute", category=DeprecationWarning)
+warnings.filterwarnings("ignore", message="builtin type swigvarlink has no __module__ attribute", category=DeprecationWarning)
+
+class TestPyMuPdfPlugin:
     def test_register_converters(self):
+        """
+        Check whether registration is called properly 
+        """
         mock_markitdown = MagicMock(spec=MarkItDown)
         register_converters(mock_markitdown)
         mock_markitdown.register_converter.assert_called_once_with(
-            unittest.mock.ANY, override=True
+            ANY, override=True
         )
-        self.assertIsInstance(
+        assert isinstance(
             mock_markitdown.register_converter.call_args[0][0], PyMuPdfConverter
         )
 
     def test_accepts(self):
+        """
+        Test detection of situations where this converter applies
+        """
         converter = PyMuPdfConverter()
         # Test with accepted extension
-        self.assertTrue(
-            converter.accepts(
-                io.BytesIO(b""), StreamInfo(extension=".pdf", mimetype="application/pdf")
-            )
+        assert converter.accepts(
+            io.BytesIO(b""), StreamInfo(extension=".pdf", mimetype="application/pdf")
         )
         # Test with accepted mimetype
-        self.assertTrue(
-            converter.accepts(
-                io.BytesIO(b""), StreamInfo(extension=".bin", mimetype="application/pdf")
-            )
+        assert converter.accepts(
+            io.BytesIO(b""), StreamInfo(extension=".bin", mimetype="application/pdf")
         )
         # Test with unaccepted extension and mimetype
-        self.assertFalse(
-            converter.accepts(
-                io.BytesIO(b""), StreamInfo(extension=".txt", mimetype="text/plain")
-            )
+        assert not converter.accepts(
+            io.BytesIO(b""), StreamInfo(extension=".txt", mimetype="text/plain")
         )
 
     def test_convert(self):
+        """
+        Test pure textual conversion to markdown
+        """
         converter = PyMuPdfConverter()
         # Create a dummy PDF in memory for testing
-        doc = fitz.open()
+        doc = pymupdf.open()
         page = doc.new_page()
         page.insert_text((10, 10), "Hello, PyMuPDF!")
         pdf_bytes = doc.tobytes()
         doc.close()
 
         result = converter.convert(
-            io.BytesIO(pdf_bytes), StreamInfo(extension=".pdf", mimetype="application/pdf")
+            io.BytesIO(pdf_bytes), StreamInfo(extension=".pdf", mimetype="application/pdf", local_path=None)
         )
-        self.assertIsInstance(result, DocumentConverterResult)
-        self.assertIn("Hello, PyMuPDF!", result.markdown)
-
-if __name__ == "__main__":
-    unittest.main()
+        assert isinstance(result, DocumentConverterResult)
+        assert "Hello, PyMuPDF!" in result.markdown
+        assert result.extracted_image_paths == [] # No images extracted in this test


### PR DESCRIPTION
- The images are extracted into an `img` subdir at the pdf source location (default) or in an optionally given dir. 
- The unambiguous image name is page_X_image_Y.<imgext>
- extraction unit tests for default and custom img dir